### PR TITLE
make the constructor public

### DIFF
--- a/busybee-android/src/main/java/io/americanexpress/busybee/android/internal/BusyBeeIdlingResource.java
+++ b/busybee-android/src/main/java/io/americanexpress/busybee/android/internal/BusyBeeIdlingResource.java
@@ -27,7 +27,7 @@ public class BusyBeeIdlingResource implements IdlingResource {
 
     private final BusyBee busyBee;
 
-    BusyBeeIdlingResource(final BusyBee busyBee) {
+    public BusyBeeIdlingResource(final BusyBee busyBee) {
         this.busyBee = busyBee;
     }
 


### PR DESCRIPTION
I'm calling this from Kotlin and getting "Cannot access <init>: it is public/*package*/ in BusyBeeIdlingResource"