### PR TITLE
Issue 9 support jvm tests in android modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
   components: 
     - tools
     - platform-tools
-    - build-tools-28.0.3
+    - build-tools-29.0.2
     - android-29
 
 script:

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/busybee-android/build.gradle
+++ b/busybee-android/build.gradle
@@ -53,5 +53,4 @@ dependencies {
 
     testImplementation "org.assertj:assertj-core:${deps.assertj}"
     testImplementation "junit:junit:${deps.junit}"
-    testImplementation "androidx.test.espresso:espresso-core:${deps.androidx.test.espresso.core}"
 }

--- a/busybee-android/build.gradle
+++ b/busybee-android/build.gradle
@@ -50,4 +50,8 @@ dependencies {
     androidTestImplementation "org.assertj:assertj-core:${deps.assertj}"
     androidTestImplementation "junit:junit:${deps.junit}"
     androidTestImplementation "androidx.test.espresso:espresso-core:${deps.androidx.test.espresso.core}"
+
+    testImplementation "org.assertj:assertj-core:${deps.assertj}"
+    testImplementation "junit:junit:${deps.junit}"
+    testImplementation "androidx.test.espresso:espresso-core:${deps.androidx.test.espresso.core}"
 }

--- a/busybee-android/src/androidTest/java/io/americanexpress/busybee/internal/AndroidMainThreadExecutorTest.kt
+++ b/busybee-android/src/androidTest/java/io/americanexpress/busybee/internal/AndroidMainThreadExecutorTest.kt
@@ -21,13 +21,13 @@ import org.junit.Test
 
 class AndroidMainThreadExecutorTest {
     @Test
-    fun whenOnAndroid_thenWeGetAndroidMainThreadExecutor() {
+    fun whenHasWorkingAndroidMainLooper_thenWeGetAndroidMainThreadExecutor() {
         assertThat(MainThread.singletonExecutor())
             .isInstanceOf(AndroidMainThreadExecutor::class.java)
     }
 
     @Test
-    fun whenOnAndroid_thenIsAndroidShouldBeTrue() {
+    fun whenHasWorkingAndroidMainLooper_thenIsAndroidShouldBeTrue() {
         assertThat(hasWorkingAndroidMainLooper()).isTrue()
     }
 }

--- a/busybee-android/src/androidTest/java/io/americanexpress/busybee/internal/AndroidMainThreadExecutorTest.kt
+++ b/busybee-android/src/androidTest/java/io/americanexpress/busybee/internal/AndroidMainThreadExecutorTest.kt
@@ -15,7 +15,7 @@
 package io.americanexpress.busybee.internal
 
 import io.americanexpress.busybee.android.internal.AndroidMainThreadExecutor
-import io.americanexpress.busybee.internal.EnvironmentChecks.isAndroid
+import io.americanexpress.busybee.internal.EnvironmentChecks.hasWorkingAndroidMainLooper
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Test
 
@@ -28,6 +28,6 @@ class AndroidMainThreadExecutorTest {
 
     @Test
     fun whenOnAndroid_thenIsAndroidShouldBeTrue() {
-        assertThat(isAndroid()).isTrue()
+        assertThat(hasWorkingAndroidMainLooper()).isTrue()
     }
 }

--- a/busybee-android/src/androidTest/java/io/americanexpress/busybee/internal/BusyBeeSingletonTest.kt
+++ b/busybee-android/src/androidTest/java/io/americanexpress/busybee/internal/BusyBeeSingletonTest.kt
@@ -15,21 +15,30 @@
 package io.americanexpress.busybee.internal
 
 import io.americanexpress.busybee.internal.EnvironmentChecks.androidJunitRunnerIsPresent
+import io.americanexpress.busybee.internal.EnvironmentChecks.junit4IsPresent
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Test
 
 class BusyBeeSingletonTest {
+
     @Test
-    fun whenIdlingResourceIncluded_thenWeDetectItsPresence() {
-        assertThat(androidJunitRunnerIsPresent())
-            .`as`("We included the idling-resource dependencies, so this should be true")
+    fun whenTestsAreRunning_thenWeDetectJunit4() {
+        assertThat(junit4IsPresent())
+            .`as`("We are running tests, so this should be true")
             .isTrue()
     }
 
     @Test
-    fun whenIdlingResourceIncluded_thenWeUseRealBusyBee() {
+    fun whenInAndroidTests_thenWeDetectItsAndroidRunner() {
+        assertThat(androidJunitRunnerIsPresent())
+            .`as`("We are running /androidTest, so this should be true")
+            .isTrue()
+    }
+
+    @Test
+    fun whenTestsAreRunning_thenWeUseRealBusyBee() {
         assertThat(BusyBeeSingleton.singleton())
-            .`as`("We included the idling-resource dependencies, so must use RealBusyBee")
+            .`as`("We are running tests, so must use RealBusyBee")
             .isInstanceOf(RealBusyBee::class.java)
     }
 }

--- a/busybee-android/src/test/java/io/americanexpress/busybee/internal/AndroidMainThreadExecutorJvmTest.kt
+++ b/busybee-android/src/test/java/io/americanexpress/busybee/internal/AndroidMainThreadExecutorJvmTest.kt
@@ -21,13 +21,13 @@ import org.junit.Test
 
 class AndroidMainThreadExecutorJvmTest {
     @Test
-    fun whenOnAndroid_thenWeGetAndroidMainThreadExecutor() {
+    fun whenDoesNotHaveWorkingAndroidMainLooper_thenWeDoNotGetAndroidMainThreadExecutor() {
         assertThat(MainThread.singletonExecutor())
             .isNotInstanceOf(AndroidMainThreadExecutor::class.java)
     }
 
     @Test
-    fun whenOnAndroid_thenIsAndroidShouldBeTrue() {
+    fun whenDoesNotHaveWorkingAndroidMainLooper_thenHasWorkingAndroidMainLooperShouldBeFalse() {
         assertThat(hasWorkingAndroidMainLooper()).isFalse()
     }
 }

--- a/busybee-android/src/test/java/io/americanexpress/busybee/internal/AndroidMainThreadExecutorJvmTest.kt
+++ b/busybee-android/src/test/java/io/americanexpress/busybee/internal/AndroidMainThreadExecutorJvmTest.kt
@@ -14,25 +14,20 @@
 
 package io.americanexpress.busybee.internal
 
-import io.americanexpress.busybee.internal.EnvironmentChecks.androidJunitRunnerIsPresent
+import io.americanexpress.busybee.android.internal.AndroidMainThreadExecutor
 import io.americanexpress.busybee.internal.EnvironmentChecks.hasWorkingAndroidMainLooper
-import io.americanexpress.busybee.internal.EnvironmentChecks.testsAreRunning
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Test
 
-class EnvironmentChecksTest {
+class AndroidMainThreadExecutorJvmTest {
     @Test
-    fun testsAreRunningShouldAlwaysBeTrueInATest() {
-        assertThat(testsAreRunning()).isTrue()
+    fun whenOnAndroid_thenWeGetAndroidMainThreadExecutor() {
+        assertThat(MainThread.singletonExecutor())
+            .isNotInstanceOf(AndroidMainThreadExecutor::class.java)
     }
 
     @Test
-    fun whenInNonAndroidModule_thenEspressoIdlingResourceIsPresentIsFalse() {
-        assertThat(androidJunitRunnerIsPresent()).isFalse()
-    }
-
-    @Test
-    fun whenInNonAndroidModule_thenIsAndroidReturnsFalse() {
+    fun whenOnAndroid_thenIsAndroidShouldBeTrue() {
         assertThat(hasWorkingAndroidMainLooper()).isFalse()
     }
 }

--- a/busybee-android/src/test/java/io/americanexpress/busybee/internal/BusyBeeSingletonJvmTest.kt
+++ b/busybee-android/src/test/java/io/americanexpress/busybee/internal/BusyBeeSingletonJvmTest.kt
@@ -15,24 +15,21 @@
 package io.americanexpress.busybee.internal
 
 import io.americanexpress.busybee.internal.EnvironmentChecks.androidJunitRunnerIsPresent
-import io.americanexpress.busybee.internal.EnvironmentChecks.hasWorkingAndroidMainLooper
-import io.americanexpress.busybee.internal.EnvironmentChecks.testsAreRunning
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Test
 
-class EnvironmentChecksTest {
+class BusyBeeSingletonJvmTest {
     @Test
-    fun testsAreRunningShouldAlwaysBeTrueInATest() {
-        assertThat(testsAreRunning()).isTrue()
+    fun whenIdlingResourceIncluded_thenWeDetectItsPresence() {
+        assertThat(androidJunitRunnerIsPresent())
+            .`as`("We included the idling-resource dependencies, so this should be true")
+            .isTrue()
     }
 
     @Test
-    fun whenInNonAndroidModule_thenEspressoIdlingResourceIsPresentIsFalse() {
-        assertThat(androidJunitRunnerIsPresent()).isFalse()
-    }
-
-    @Test
-    fun whenInNonAndroidModule_thenIsAndroidReturnsFalse() {
-        assertThat(hasWorkingAndroidMainLooper()).isFalse()
+    fun whenIdlingResourceIncluded_thenWeUseRealBusyBee() {
+        assertThat(BusyBeeSingleton.singleton())
+            .`as`("We included the idling-resource dependencies, so must use RealBusyBee")
+            .isInstanceOf(RealBusyBee::class.java)
     }
 }

--- a/busybee-android/src/test/java/io/americanexpress/busybee/internal/BusyBeeSingletonJvmTest.kt
+++ b/busybee-android/src/test/java/io/americanexpress/busybee/internal/BusyBeeSingletonJvmTest.kt
@@ -15,21 +15,30 @@
 package io.americanexpress.busybee.internal
 
 import io.americanexpress.busybee.internal.EnvironmentChecks.androidJunitRunnerIsPresent
+import io.americanexpress.busybee.internal.EnvironmentChecks.junit4IsPresent
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Test
 
 class BusyBeeSingletonJvmTest {
+
     @Test
-    fun whenIdlingResourceIncluded_thenWeDetectItsPresence() {
-        assertThat(androidJunitRunnerIsPresent())
-            .`as`("We included the idling-resource dependencies, so this should be true")
+    fun whenJunit4IsUsed_thenWeDetectItsPresence() {
+        assertThat(junit4IsPresent())
+            .`as`("We are running Junit4 tests, so this should be true")
             .isTrue()
     }
 
     @Test
-    fun whenIdlingResourceIncluded_thenWeUseRealBusyBee() {
+    fun whenRunningJvmTestsWithoutEspresso_thenWeDontDetectIt() {
+        assertThat(androidJunitRunnerIsPresent())
+            .`as`("We are in /test without espresso, so this should be false")
+            .isFalse()
+    }
+
+    @Test
+    fun whenTestsAreRunning_thenWeUseRealBusyBee() {
         assertThat(BusyBeeSingleton.singleton())
-            .`as`("We included the idling-resource dependencies, so must use RealBusyBee")
+            .`as`("We are running tests, so must use RealBusyBee")
             .isInstanceOf(RealBusyBee::class.java)
     }
 }

--- a/busybee-core/src/main/java/io/americanexpress/busybee/internal/EnvironmentChecks.java
+++ b/busybee-core/src/main/java/io/americanexpress/busybee/internal/EnvironmentChecks.java
@@ -16,6 +16,16 @@ package io.americanexpress.busybee.internal;
 
 import androidx.annotation.VisibleForTesting;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeoutException;
+
+import static io.americanexpress.busybee.internal.Reflection.clazz;
+import static io.americanexpress.busybee.internal.Reflection.invokeMethod;
+import static io.americanexpress.busybee.internal.Reflection.invokeStaticMethod;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 public class EnvironmentChecks {
 
     @VisibleForTesting
@@ -37,8 +47,25 @@ public class EnvironmentChecks {
         return Reflection.classIsFound("androidx.test.runner.AndroidJUnitRunner");
     }
 
-    static boolean isAndroid() {
-        return Reflection.classIsFound("android.app.Application");
+    // can't reference Android types directly, so have to use raw types.
+    @SuppressWarnings({"rawtypes"})
+    static boolean hasWorkingAndroidMainLooper() {
+        Class looperClass = clazz("android.os.Looper");
+        Object mainLooper;
+        try {
+            mainLooper = invokeStaticMethod(looperClass, "getMainLooper");
+        } catch (InvocationTargetException e) {
+            return false;
+        }
+        Class handlerClass = clazz("android.os.Handler");
+        Object handler = Reflection.invokeConstructor(handlerClass, looperClass, mainLooper);
+        FutureTask<Boolean> runnable = new FutureTask<>(() -> true);
+        invokeMethod(handler, "postAtFrontOfQueue", new Class[]{Runnable.class}, new Object[]{runnable});
+        try {
+            return runnable.get(2, SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            return false;
+        }
     }
 
     @VisibleForTesting

--- a/busybee-core/src/main/java/io/americanexpress/busybee/internal/EnvironmentChecks.java
+++ b/busybee-core/src/main/java/io/americanexpress/busybee/internal/EnvironmentChecks.java
@@ -38,7 +38,8 @@ public class EnvironmentChecks {
         return junit4IsPresent() || androidJunitRunnerIsPresent();
     }
 
-    private static boolean junit4IsPresent() {
+    @VisibleForTesting
+    static boolean junit4IsPresent() {
         return Reflection.classIsFound("org.junit.runners.JUnit4");
     }
 

--- a/busybee-core/src/main/java/io/americanexpress/busybee/internal/Reflection.java
+++ b/busybee-core/src/main/java/io/americanexpress/busybee/internal/Reflection.java
@@ -39,10 +39,10 @@ class Reflection {
         }
     }
 
-    static Object invokeStaticMethod(Class<?> clazz, String methodName) throws InvocationTargetException {
+    static Object invokeStaticMethod(Class<?> clazz, String methodName) {
         try {
             return clazz.getMethod(methodName).invoke(null);
-        } catch (NoSuchMethodException | IllegalAccessException e) {
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
     }

--- a/busybee-core/src/main/java/io/americanexpress/busybee/internal/Reflection.java
+++ b/busybee-core/src/main/java/io/americanexpress/busybee/internal/Reflection.java
@@ -14,8 +14,14 @@
 
 package io.americanexpress.busybee.internal;
 
-import java.lang.reflect.Field;
+import org.jetbrains.annotations.NotNull;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+
+// we are doing a number of type-unsafe things here to seamlessly detect whether we are on Android or not.
+// Can't use the actual Android types because they might not exist, if we are in a pure JVM module
+@SuppressWarnings({"unchecked", "rawtypes"})
 class Reflection {
     static Object getValue(Field instance) {
         try {
@@ -25,12 +31,44 @@ class Reflection {
         }
     }
 
-    static Field getField(Class<?> androidExecutorClass1, String fieldName) {
+    static Field getField(Class<?> clazz, String fieldName) {
         try {
-            return androidExecutorClass1.getDeclaredField(fieldName);
+            return clazz.getDeclaredField(fieldName);
         } catch (NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    static Object invokeStaticMethod(Class<?> clazz, String methodName) throws InvocationTargetException {
+        try {
+            return clazz.getMethod(methodName).invoke(null);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Object invokeMethod(Object instance, String methodName, Class[] argTypes, Object[] args) {
+        try {
+            return instance.getClass().getMethod(methodName, argTypes).invoke(instance, args);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NotNull
+    static Class<?> clazz(String className) {
+        return clazz(className, "Error calling Class.forName on " + className);
+    }
+
+    @NotNull
+    static Class<?> clazz(String className, String notFoundErrorMessage) {
+        Class<?> androidExecutorClass;
+        try {
+            androidExecutorClass = Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(notFoundErrorMessage, e);
+        }
+        return androidExecutorClass;
     }
 
     static boolean classIsFound(String className) {
@@ -40,5 +78,13 @@ class Reflection {
             return false;
         }
         return true;
+    }
+
+    static Object invokeConstructor(Class classToConstruct, Class constructorArgType, Object constructorArg) {
+        try {
+            return classToConstruct.getConstructor(constructorArgType).newInstance(constructorArg);
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -13,6 +13,6 @@
 #
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes https://github.com/americanexpress/busybee/issues/9

We need to test the scenario of Busybee being used in `/test` in an Android module.

Instead of only checking for presence of `android.app.Application`, we try to load up the main looper and make sure it can execute a runnable.

Previously, this failed with:
```
Caused by: java.lang.RuntimeException: Method getMainLooper in android.os.Looper not mocked. See http://g.co/androidstudio/not-mocked for details.
	at android.os.Looper.getMainLooper(Looper.java)
	at io.americanexpress.busybee.android.internal.AndroidMainThreadExecutor.<init>(AndroidMainThreadExecutor.java:27)
	at io.americanexpress.busybee.android.internal.AndroidMainThreadExecutor.<clinit>(AndroidMainThreadExecutor.java:25)
```
