### PR TITLE
Fix publish of busybee-core

### DIFF
--- a/busybee-core/build.gradle
+++ b/busybee-core/build.gradle
@@ -12,6 +12,7 @@
  * the License.
  */
 plugins {
+    id 'java-library'
     id 'org.jetbrains.kotlin.jvm'
 }
 

--- a/busybee-core/src/main/java/io/americanexpress/busybee/BusyBee.java
+++ b/busybee-core/src/main/java/io/americanexpress/busybee/BusyBee.java
@@ -22,9 +22,11 @@ public interface BusyBee {
 
     /**
      * Generally, you want just one instance of BusyBee for your whole process.
-     *
+     * <p>
      * For release apps with no tests running, this will return a instance of BusyBee
      * that does nothing, so there is minimal overhead for your release builds.
+     *
+     * @return the single global instance of BusyBee
      */
     static @NonNull
     BusyBee singleton() {
@@ -52,6 +54,7 @@ public interface BusyBee {
      * Record the start of an async operation.
      *
      * @param operation An object that identifies the request. Must have a correct equals()/hashCode().
+     * @param category Which {@link Category} the given operation will be associated with
      */
     void busyWith(@NonNull Object operation, @NonNull BusyBee.Category category);
 


### PR DESCRIPTION
Seems this broke when we upgraded to Gradle 6.5.
We need to explicitly add the java-library plugin so we can detect it and add the correct publishing config.
:busybee-core:publish was UP-TO-DATE because the publication tasks were getting created in the root build.gradle,
because plugins.hasPlugin('java-library') was returning false for busybee-core.

Also, have to fix the javadoc's so the javadoc task doesn't fail.