### PR TITLE
Publish to maven central

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,10 @@ version: 2.1
 executors:
   android-api29:
     docker:
-      # https://hub.docker.com/layers/circleci/android/api-29/images/sha256-2f83a26e7d875a74c2fd4edb643168654bc8028a258bcc71a6bfd1ea26580f82?context=explore
-      - image: circleci/android@sha256:2f83a26e7d875a74c2fd4edb643168654bc8028a258bcc71a6bfd1ea26580f82
+      # https://hub.docker.com/layers/circleci/android/api-29/images/sha256-9fc0f34301182ba3730b1ca085e827927675168e57d412f6cc86256c7cd28e2d
+      #  api-29, JDK 11.0.10, commandlinetools-linux-6609375_latest.zip
+      - image: circleci/android@sha256:9fc0f34301182ba3730b1ca085e827927675168e57d412f6cc86256c7cd28e2d
+
 
 anchors:
   - &common_job_config
@@ -27,7 +29,7 @@ jobs:
       - checkout
       - run:
           name: Publish -SNAPSHOT
-          command: MAVEN_REPO_URL="https://oss.jfrog.org/artifactory/oss-snapshot-local/" ./gradlew build publish --stacktrace
+          command: MAVEN_REPO_URL="https://s01.oss.sonatype.org/content/repositories/snapshots/" ./gradlew build publish --stacktrace
 
   publish-release:
     <<: *common_job_config
@@ -35,12 +37,14 @@ jobs:
       - checkout
       - run:
           name: Publish Release
-          command: MAVEN_REPO_URL="https://api.bintray.com/maven/americanexpress/maven/io.americanexpress.busybee/;publish=0" ./gradlew build publish -Dsnapshot=false --stacktrace
+          command: MAVEN_REPO_URL="https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/" ./gradlew build publish -Dsnapshot=false --stacktrace
 
 
 workflows_setup:
   - &context
-    context: gradle
+    context:
+      - maven_central_credentials
+      - code_signing_credentials
 
   - &default_branch
       "main"

--- a/build.gradle
+++ b/build.gradle
@@ -165,11 +165,14 @@ subprojects {
                     }
                 }
             }
-            signing {
-                def signingKey = new String(Base64.decoder.decode(findProperty("signingKey_base64")), Charset.forName("UTF-8"))
-                def signingPassword = findProperty("signingPassword")
-                useInMemoryPgpKeys(signingKey, signingPassword)
-                sign publishing.publications.busybee
+            def signingKeyBase64 = findProperty("signingKey_base64")
+            if (signingKeyBase64 != null) {
+                signing {
+                    def signingKey = new String(Base64.decoder.decode(signingKeyBase64), Charset.forName("UTF-8"))
+                    def signingPassword = findProperty("signingPassword")
+                    useInMemoryPgpKeys(signingKey, signingPassword)
+                    sign publishing.publications.busybee
+                }
             }
         }
 
@@ -228,11 +231,14 @@ subprojects {
                             }
                         }
                     }
-                    signing {
-                        def signingKey = new String(Base64.decoder.decode(findProperty("signingKey_base64")), Charset.forName("UTF-8"))
-                        def signingPassword = findProperty("signingPassword")
-                        useInMemoryPgpKeys(signingKey, signingPassword)
-                        sign publishing.publications.busybee
+                    def signingKeyBase64 = findProperty("signingKey_base64")
+                    if (signingKeyBase64 != null) {
+                        signing {
+                            def signingKey = new String(Base64.decoder.decode(signingKeyBase64), Charset.forName("UTF-8"))
+                            def signingPassword = findProperty("signingPassword")
+                            useInMemoryPgpKeys(signingKey, signingPassword)
+                            sign publishing.publications.busybee
+                        }
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.nio.charset.Charset
+
 /*
  * Copyright 2020 American Express Travel Related Services Company, Inc.
  *
@@ -18,6 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.32'
         classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -56,7 +59,9 @@ subprojects {
 
     ext.compilerArgs = ["-Werror"]
 
+    apply plugin: 'org.jetbrains.dokka'
     apply plugin: 'maven-publish'
+    apply plugin: 'signing'
 
     group = rootProject.group
     version = rootProject.version
@@ -85,6 +90,9 @@ subprojects {
                     jvmTarget = "1.8"
                 }
             }
+            java {
+                withSourcesJar()
+            }
         }
 
         if (plugins.hasPlugin('com.android.library')
@@ -102,26 +110,24 @@ subprojects {
             }
         }
 
+        // Use getenv so they can be passed in without having them in a file
+        // or in the command args
+        def maven_username = System.getenv('MAVEN_CENTRAL_USERNAME') ?: ''
+        def maven_password = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: ''
+
         // from https://docs.gradle.org/current/userguide/publishing_maven.html
         if (plugins.hasPlugin('java-library')) {
-            task sourcesJar(type: Jar){
-                from sourceSets.main.allJava
-                getArchiveClassifier().set('sources')
-            }
-
-            task javadocJar(type: Jar){
-                from javadoc
-                getArchiveClassifier().set('javadoc')
-            }
-
             publishing {
+                task dokkaJavadocJar(type: Jar) {
+                    from dokkaJavadoc.outputDirectory
+                }
                 repositories {
                     maven {
                         // Use getenv so they can be passed in without having them in a file
                         // or in the command args
                         credentials {
-                            username System.getenv('MAVEN_REPO_USERNAME') ?: ''
-                            password System.getenv('MAVEN_REPO_PASSWORD') ?: ''
+                            username maven_username
+                            password maven_password
                         }
 
                         url System.getenv('MAVEN_REPO_URL')
@@ -132,66 +138,101 @@ subprojects {
                     // artifactId comes from the name of the gradle module
                     busybee(MavenPublication) {
                         from components.java
-                        artifact sourcesJar
-                        artifact javadocJar
+                        artifact dokkaJavadocJar {
+                            getArchiveClassifier().set('javadoc')
+                        }
+                        pom {
+                            name = 'busybee'
+                            description = 'BusyBee is an alternative API for IdlingResources in Espresso tests.'
+                            url = 'https://github.com/americanexpress/busybee'
+                            licenses {
+                                license {
+                                    name = 'The Apache License, Version 2.0'
+                                    url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                                }
+                            }
+                            developers {
+                                developer {
+                                    name = 'American Express Travel Related Services Company, Inc.'
+                                }
+                            }
+                            scm {
+                                connection = 'scm:git:https://github.com/americanexpress/busybee.git'
+                                developerConnection = 'scm:git:git@github.com:americanexpress/busybee.git'
+                                url = 'https://github.com/americanexpress/busybee'
+                            }
+                        }
                     }
                 }
+            }
+            signing {
+                def signingKey = new String(Base64.decoder.decode(findProperty("signingKey_base64")), Charset.forName("UTF-8"))
+                def signingPassword = findProperty("signingPassword")
+                useInMemoryPgpKeys(signingKey, signingPassword)
+                sign publishing.publications.busybee
             }
         }
 
         if (plugins.hasPlugin('com.android.library')) {
-            task releaseSourcesJar(type: Jar) {
-                getArchiveClassifier().set('sources')
-                from android.sourceSets.release.java.srcDirs
-            }
-
-            artifacts {
-                archives releaseSourcesJar
-            }
-
-            task androidSourcesJar(type: Jar) {
-                from android.sourceSets.main.java.srcDirs
-            }
-
-            publishing {
-                repositories {
-                    maven {
-                        // Use getenv so they can be passed in without having them in a file
-                        // or in the command args
-                        credentials {
-                            username System.getenv('MAVEN_REPO_USERNAME') ?: ''
-                            password System.getenv('MAVEN_REPO_PASSWORD') ?: ''
-                        }
-
-                        url System.getenv('MAVEN_REPO_URL')
-                    }
+            // need afterEvaluate else the components.release will be missing below
+            afterEvaluate {
+                // need this until it is built into AGP, see https://issuetracker.google.com/issues/145670440
+                task androidSourcesJar(type: Jar) {
+                    from android.sourceSets.main.java.srcDirs
                 }
-                publications {
-                    // groupId and version come from gradle.properties
-                    // artifactId comes from the name of the gradle module
-                    busybee(MavenPublication) {
-                        artifact("build/outputs/aar/${project.name}-release.aar")
+                task dokkaJavadocJar(type: Jar) {
+                    from dokkaJavadoc.outputDirectory
+                }
+                publishing {
+                    repositories {
+                        maven {
+                            credentials {
+                                username maven_username
+                                password maven_password
+                            }
 
-                        artifact androidSourcesJar {
-                            getArchiveClassifier().set('sources')
+                            url System.getenv('MAVEN_REPO_URL')
                         }
-
-                        // Manually add the dependencies because the android plugin does not support SoftwareComponent
-                        pom.withXml {
-                            def dependenciesNode = asNode().appendNode('dependencies')
-
-                            configurations.implementation.allDependencies.each {
-                                def dependencyNode = dependenciesNode.appendNode('dependency')
-                                dependencyNode.appendNode('groupId', it.group)
-                                dependencyNode.appendNode('artifactId', it.name)
-
-                                if (it.group == group) {
-                                    dependencyNode.appendNode('version', version)
-                                } else {
-                                    dependencyNode.appendNode('version', it.version)
+                    }
+                    publications {
+                        // groupId and version come from gradle.properties
+                        // artifactId comes from the name of the gradle module
+                        busybee(MavenPublication) {
+                            from components.release
+                            artifact androidSourcesJar {
+                                getArchiveClassifier().set('sources')
+                            }
+                            artifact dokkaJavadocJar {
+                                getArchiveClassifier().set('javadoc')
+                            }
+                            pom {
+                                name = 'busybee'
+                                description = 'BusyBee is an alternative API for IdlingResources in Espresso tests.'
+                                url = 'https://github.com/americanexpress/busybee'
+                                licenses {
+                                    license {
+                                        name = 'The Apache License, Version 2.0'
+                                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                                    }
+                                }
+                                developers {
+                                    developer {
+                                        name = 'American Express Travel Related Services Company, Inc.'
+                                    }
+                                }
+                                scm {
+                                    connection = 'scm:git:https://github.com/americanexpress/busybee.git'
+                                    developerConnection = 'scm:git:git@github.com:americanexpress/busybee.git'
+                                    url = 'https://github.com/americanexpress/busybee'
                                 }
                             }
                         }
+                    }
+                    signing {
+                        def signingKey = new String(Base64.decoder.decode(findProperty("signingKey_base64")), Charset.forName("UTF-8"))
+                        def signingPassword = findProperty("signingPassword")
+                        useInMemoryPgpKeys(signingKey, signingPassword)
+                        sign publishing.publications.busybee
                     }
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,7 @@
 #
 android.useAndroidX=true
 systemProp.group=io.americanexpress.busybee
-systemProp.version=0.0.3
+systemProp.version=0.0.4
 kotlin.code.style=official
+# Dokka needs more memory than the default provides.
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
implements #21 

Maven Central has additional requirements for publishing compared to jCenter. 

We need to:
- add developer info to the pom
- provide javadocs (via Dokka)
- Sign the artifacts
- Update the repo urls used for publishing

We need to some DRY clean up, but tried to keep changes to a minimum and focused on just getting things publishing to maven central. 

Tested here: 
https://app.circleci.com/pipelines/github/americanexpress/busybee/52/workflows/f29f8c58-4f7d-43c1-8375-ce63ca2d33ee