### PR TITLE
Set a max name for the IdlingResource

### DIFF
--- a/busybee-android/src/main/java/io/americanexpress/busybee/android/internal/BusyBeeIdlingResource.kt
+++ b/busybee-android/src/main/java/io/americanexpress/busybee/android/internal/BusyBeeIdlingResource.kt
@@ -24,8 +24,11 @@ import io.americanexpress.busybee.BusyBee
  * You must register it with Espresso:
  * `IdlingRegistry.getInstance().register(new BusyBeeIdlingResource(BusyBee.singleton()));`
  */
+
+private const val NAME_MAX_LENGTH = 100
+
 class BusyBeeIdlingResource internal constructor(private val busyBee: BusyBee) : IdlingResource {
-    override fun getName() = busyBee.getName()
+    override fun getName() = busyBee.getName().take(NAME_MAX_LENGTH)
 
     override fun isIdleNow() = busyBee.isNotBusy()
 


### PR DESCRIPTION
When tracing is enabled in the app, Espresso add IdlingResources to traces. This can cause `IllegalArgumentException` because `createUnmanagedSpan` calls `IdlingResource.getName()` and BusyBee returns a String that is not bounded:

```
override fun getName() = busyBee.getName()
```

This PR set a limit of 100 for the resource name. `Trace` has a limit of 127 characters. But I wanted to be on the safe side if there's a mechanism that adds prefix or suffix eventually.

The stacktrace that shows this error:
```
2022-10-28 12:48:39.111 19053-19108/com.example E/TestRunner: java.lang.IllegalArgumentException: sectionName is too long
        at android.os.Trace.beginSection(Trace.java:384)
        at androidx.tracing.TraceApi18Impl.beginSection(TraceApi18Impl.java:49)
        at androidx.tracing.Trace.beginSection(Trace.java:129)
        at androidx.test.platform.tracing.AndroidXTracer.beginSpan(AndroidXTracer.java:44)
        at androidx.test.platform.tracing.Tracing.createUnmanagedSpan(Tracing.java:171)
        at androidx.test.platform.tracing.Tracing.beginSpan(Tracing.java:113)
        at androidx.test.espresso.base.IdlingResourceRegistry$IdlingState.createUnmanagedTracerSpan(IdlingResourceRegistry.java:1)
        at androidx.test.espresso.base.IdlingResourceRegistry$IdlingState.setIdle(IdlingResourceRegistry.java:2)
        at androidx.test.espresso.base.IdlingResourceRegistry.allResourcesAreIdle(IdlingResourceRegistry.java:4)
        at androidx.test.espresso.base.IdlingResourceRegistry$6.isIdleNow(IdlingResourceRegistry.java:1)
```